### PR TITLE
Add tests

### DIFF
--- a/src/components/stable-component.test.tsx
+++ b/src/components/stable-component.test.tsx
@@ -1,0 +1,154 @@
+import { useState, useEffect } from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { useConvertToLucyState } from "../convert-into-lucy-state";
+import { StableComponent } from "./stable-component";
+
+import type { LucyState } from "../types";
+
+describe("<StableComponent />", () => {
+  it("does not re-render the stable component", async () => {
+    const spy = jest.fn();
+    function Content({ state }: { state: string }) {
+      useEffect(() => {
+        spy();
+      });
+
+      return <h2>Stable Content value: {state}</h2>;
+    }
+    function Component() {
+      const [state, setState] = useState("initial state");
+
+      return (
+        <div>
+          <button onClick={() => setState("first state")}>First button</button>
+          <StableComponent>
+            <Content state={state} />
+          </StableComponent>
+        </div>
+      );
+    }
+
+    render(<Component />);
+
+    const user = userEvent.setup();
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole("heading", { level: 2 })).toHaveTextContent(
+      "Stable Content value: initial state"
+    );
+
+    await user.click(screen.getByRole("button", { name: "First button" }));
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole("heading", { level: 2 })).toHaveTextContent(
+      "Stable Content value: initial state"
+    );
+  });
+
+  it("does not re-render stable component inline content", async () => {
+    function Component() {
+      const [state, setState] = useState("initial state");
+
+      return (
+        <div>
+          <button onClick={() => setState("first state")}>First button</button>
+          <StableComponent>
+            <h2>Stable Content value: {state}</h2>
+          </StableComponent>
+        </div>
+      );
+    }
+
+    render(<Component />);
+
+    const user = userEvent.setup();
+
+    expect(screen.getByRole("heading", { level: 2 })).toHaveTextContent(
+      "Stable Content value: initial state"
+    );
+
+    await user.click(screen.getByRole("button", { name: "First button" }));
+
+    expect(screen.getByRole("heading", { level: 2 })).toHaveTextContent(
+      "Stable Content value: initial state"
+    );
+  });
+
+  it("updates the stable component correctly if LucyState is passed inline", async () => {
+    function Component() {
+      const [state, setState] = useState("initial state");
+      const state$ = useConvertToLucyState(state);
+
+      return (
+        <div>
+          <button onClick={() => setState("first state")}>First button</button>
+          <StableComponent>
+            <h2>
+              Stable Content value: <state$.Value />
+            </h2>
+          </StableComponent>
+        </div>
+      );
+    }
+
+    render(<Component />);
+
+    const user = userEvent.setup();
+
+    expect(screen.getByRole("heading", { level: 2 })).toHaveTextContent(
+      "Stable Content value: initial state"
+    );
+
+    await user.click(screen.getByRole("button", { name: "First button" }));
+
+    expect(screen.getByRole("heading", { level: 2 })).toHaveTextContent(
+      "Stable Content value: first state"
+    );
+  });
+
+  it("updates the stable component correctly if LucyState is passed as a prop", async () => {
+    const spy = jest.fn();
+    function Content({ state$ }: { state$: LucyState<string> }) {
+      useEffect(() => {
+        spy();
+      });
+
+      return (
+        <h2>
+          Stable Content value: <state$.Value />
+        </h2>
+      );
+    }
+    function Component() {
+      const [state, setState] = useState("initial state");
+      const state$ = useConvertToLucyState(state);
+
+      return (
+        <div>
+          <button onClick={() => setState("first state")}>First button</button>
+          <StableComponent>
+            <Content state$={state$} />
+          </StableComponent>
+        </div>
+      );
+    }
+
+    render(<Component />);
+
+    const user = userEvent.setup();
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole("heading", { level: 2 })).toHaveTextContent(
+      "Stable Content value: initial state"
+    );
+
+    await user.click(screen.getByRole("button", { name: "First button" }));
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole("heading", { level: 2 })).toHaveTextContent(
+      "Stable Content value: first state"
+    );
+  });
+});

--- a/src/create-lucy-state.ts
+++ b/src/create-lucy-state.ts
@@ -1,6 +1,6 @@
-import React, { useState, createElement, useEffect, useRef, memo } from "react";
+import React, { useState, useEffect, useRef, memo } from "react";
 
-import type { LucyState } from "./types";
+import type { LucyState } from "../src/types";
 
 const noValueSymbol = Symbol("no value");
 

--- a/src/lucy-state-value-component.test.tsx
+++ b/src/lucy-state-value-component.test.tsx
@@ -1,0 +1,190 @@
+import { useEffect } from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { useLucyState } from "./use-lucy-state";
+
+describe("<state$.Value />", () => {
+  it("renders the string value if no children are provided", async () => {
+    const user = userEvent.setup();
+    let newValue = "Updated value";
+    function Component() {
+      const state$ = useLucyState("Default value");
+
+      return (
+        <div>
+          <h1>
+            <state$.Value />
+          </h1>
+          <button onClick={() => state$.setValue(newValue)}>
+            Change value
+          </button>
+        </div>
+      );
+    }
+
+    render(<Component />);
+
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
+      "Default value"
+    );
+
+    await user.click(screen.getByRole("button", { name: "Change value" }));
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
+      "Updated value"
+    );
+  });
+
+  it("renders the number value if no children are provided", async () => {
+    const user = userEvent.setup();
+    let newValue = 20;
+    function Component() {
+      const state$ = useLucyState(10);
+
+      return (
+        <div>
+          <h1>
+            State value is: <state$.Value />
+          </h1>
+          <button onClick={() => state$.setValue(newValue)}>
+            Change value
+          </button>
+        </div>
+      );
+    }
+
+    render(<Component />);
+
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
+      "State value is: 10"
+    );
+
+    await user.click(screen.getByRole("button", { name: "Change value" }));
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
+      "State value is: 20"
+    );
+  });
+
+  it("executes child callback correctly", async () => {
+    const user = userEvent.setup();
+    let newValue = 15;
+    function Component() {
+      const state$ = useLucyState(5);
+
+      return (
+        <div>
+          <state$.Value>
+            {(value) => <h1>State value is: {value}</h1>}
+          </state$.Value>
+
+          <button onClick={() => state$.setValue(newValue)}>
+            Change value
+          </button>
+        </div>
+      );
+    }
+
+    render(<Component />);
+
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
+      "State value is: 5"
+    );
+
+    await user.click(screen.getByRole("button", { name: "Change value" }));
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
+      "State value is: 15"
+    );
+  });
+
+  it("executes selector callback correctly", async () => {
+    const user = userEvent.setup();
+    let newValue = {
+      value: 11,
+      textValue: "New value",
+    };
+    function Component() {
+      const state$ = useLucyState({
+        value: 9,
+        textValue: "Initial value",
+      });
+
+      return (
+        <div>
+          <state$.Value selector={(state) => state.value}>
+            {(value) => <h1>State value is: {value}</h1>}
+          </state$.Value>
+
+          <button onClick={() => state$.setValue(newValue)}>
+            Change value
+          </button>
+        </div>
+      );
+    }
+
+    render(<Component />);
+
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
+      "State value is: 9"
+    );
+
+    await user.click(screen.getByRole("button", { name: "Change value" }));
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
+      "State value is: 11"
+    );
+  });
+
+  it("executes child callback only when the selector result changes", async () => {
+    const spy = jest.fn();
+    const user = userEvent.setup();
+    let newValue = {
+      value: 5,
+      textValue: "New value",
+    };
+    function Content({ value }: { value: number }) {
+      useEffect(spy);
+
+      return <h1>State value is: {value}</h1>;
+    }
+    function Component() {
+      const state$ = useLucyState({
+        value: 2,
+        textValue: "Initial value",
+      });
+
+      return (
+        <div>
+          <state$.Value selector={(state) => state.value}>
+            {(value) => <Content value={value} />}
+          </state$.Value>
+
+          <button onClick={() => state$.setValue(newValue)}>
+            Change value
+          </button>
+        </div>
+      );
+    }
+
+    render(<Component />);
+
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
+      "State value is: 2"
+    );
+
+    await user.click(screen.getByRole("button", { name: "Change value" }));
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
+      "State value is: 5"
+    );
+
+    expect(spy).toHaveBeenCalledTimes(2);
+
+    newValue = {
+      value: 5,
+      textValue: "something new",
+    };
+
+    await user.click(screen.getByRole("button", { name: "Change value" }));
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -12,7 +12,7 @@ export type LucyState<T> = {
   }) => React.ReactNode;
   useTrackValue: (
     cb: (value: T) => void | Function,
-    options: {
+    options?: {
       skipFirstCall?: boolean;
       comparator?: (a: T, b: T) => boolean;
     }

--- a/src/utils/combine.ts
+++ b/src/utils/combine.ts
@@ -1,4 +1,4 @@
-import { useLucyState } from "./use-lucy-state";
+import { useLucyState } from "../use-lucy-state";
 
 type createdState<StateType> = ReturnType<typeof useLucyState<StateType>>;
 

--- a/src/utils/select.ts
+++ b/src/utils/select.ts
@@ -1,4 +1,4 @@
-import { useLucyState } from "./use-lucy-state";
+import { useLucyState } from "../use-lucy-state";
 
 type State<StateType> = ReturnType<typeof useLucyState<StateType>>;
 

--- a/tests/lucy-state-list.test.tsx
+++ b/tests/lucy-state-list.test.tsx
@@ -1,0 +1,212 @@
+import { useEffect } from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { StableIteratorComponent } from "../src/components/stable-iterator-component";
+import { useLucyState } from "../src/use-lucy-state";
+
+import type { LucyState } from "../src/types";
+
+type Task = { id: number; content: string };
+
+describe("Lucy State lists", () => {
+  it("only re-renders list items which changed", async () => {
+    const user = userEvent.setup();
+    const spy = jest.fn();
+    const task1: Task = { id: 1, content: "First task" };
+    const task2: Task = { id: 2, content: "Second task" };
+    const task3: Task = { id: 3, content: "Third task" };
+    const task4: Task = { id: 4, content: "Fourth task" };
+    const task5: Task = { id: 5, content: "Fifth task" };
+    let newTasks: Task[] = [];
+    function ItemComponent({ task$ }: { task$: LucyState<Task> }) {
+      useEffect(spy);
+
+      return (
+        <li>
+          <task$.Value selector={(task) => task.content} />
+        </li>
+      );
+    }
+    function Component() {
+      const tasks$ = useLucyState([task1, task2, task3, task4, task5]);
+
+      return (
+        <div>
+          <ul aria-label="tasks">
+            <tasks$.Value>
+              {(tasks) =>
+                tasks.map((task, index) => (
+                  <StableIteratorComponent
+                    item={task}
+                    index={index}
+                    key={task.id}
+                  >
+                    {(task$) => <ItemComponent task$={task$} />}
+                  </StableIteratorComponent>
+                ))
+              }
+            </tasks$.Value>
+          </ul>
+          <button onClick={() => tasks$.setValue(newTasks)}>
+            Change tasks
+          </button>
+        </div>
+      );
+    }
+
+    render(<Component />);
+
+    expect(spy).toHaveBeenCalledTimes(5);
+
+    newTasks = [
+      task1,
+      task2,
+      { id: 3, content: "new task 3 content" },
+      task4,
+      task5,
+    ];
+    await user.click(screen.getByRole("button", { name: "Change tasks" }));
+
+    // just checking that nothing remounted; the components are stable and won't re-render
+    expect(spy).toHaveBeenCalledTimes(5);
+
+    expect(screen.getByRole("list", { name: "tasks" })).toHaveTextContent(
+      newTasks.map((task) => task.content).join("")
+    );
+  });
+
+  it("does not re-render existing list items when adding a new item", async () => {
+    const user = userEvent.setup();
+    const spy = jest.fn();
+    const task1: Task = { id: 1, content: "First task" };
+    const task2: Task = { id: 2, content: "Second task" };
+    const task3: Task = { id: 3, content: "Third task" };
+    const task4: Task = { id: 4, content: "Fourth task" };
+    const task5: Task = { id: 5, content: "Fifth task" };
+    let newTasks: Task[] = [];
+    function ItemComponent({ task$ }: { task$: LucyState<Task> }) {
+      useEffect(spy);
+
+      return (
+        <li>
+          <task$.Value selector={(task) => task.content} />
+        </li>
+      );
+    }
+    function Component() {
+      const tasks$ = useLucyState([task1, task2, task3, task4, task5]);
+
+      return (
+        <div>
+          <ul aria-label="tasks">
+            <tasks$.Value>
+              {(tasks) =>
+                tasks.map((task, index) => (
+                  <StableIteratorComponent
+                    item={task}
+                    index={index}
+                    key={task.id}
+                  >
+                    {(task$) => <ItemComponent task$={task$} />}
+                  </StableIteratorComponent>
+                ))
+              }
+            </tasks$.Value>
+          </ul>
+          <button onClick={() => tasks$.setValue(newTasks)}>
+            Change tasks
+          </button>
+        </div>
+      );
+    }
+
+    render(<Component />);
+
+    expect(spy).toHaveBeenCalledTimes(5);
+
+    newTasks = [
+      task1,
+      task2,
+      task3,
+      task4,
+      task5,
+      { id: 6, content: "Sixth task" },
+    ];
+    await user.click(screen.getByRole("button", { name: "Change tasks" }));
+
+    expect(spy).toHaveBeenCalledTimes(6);
+
+    expect(screen.getByRole("list", { name: "tasks" })).toHaveTextContent(
+      newTasks.map((task) => task.content).join("")
+    );
+  });
+
+  it("does update index correctly if it changes", async () => {
+    const user = userEvent.setup();
+    const spy = jest.fn();
+    const task1: Task = { id: 1, content: "First task" };
+    const task2: Task = { id: 2, content: "Second task" };
+    const task3: Task = { id: 3, content: "Third task" };
+    const task4: Task = { id: 4, content: "Fourth task" };
+    const task5: Task = { id: 5, content: "Fifth task" };
+    let newTasks: Task[] = [];
+    function ItemComponent({
+      task$,
+      index$,
+    }: {
+      task$: LucyState<Task>;
+      index$: LucyState<number>;
+    }) {
+      useEffect(spy);
+
+      return (
+        <li>
+          <index$.Value />:
+          <task$.Value selector={(task) => task.content} />
+        </li>
+      );
+    }
+    function Component() {
+      const tasks$ = useLucyState([task1, task2, task3, task4, task5]);
+
+      return (
+        <div>
+          <ul aria-label="tasks">
+            <tasks$.Value>
+              {(tasks) =>
+                tasks.map((task, index) => (
+                  <StableIteratorComponent
+                    item={task}
+                    index={index}
+                    key={task.id}
+                  >
+                    {(task$, index$) => (
+                      <ItemComponent task$={task$} index$={index$} />
+                    )}
+                  </StableIteratorComponent>
+                ))
+              }
+            </tasks$.Value>
+          </ul>
+          <button onClick={() => tasks$.setValue(newTasks)}>
+            Change tasks
+          </button>
+        </div>
+      );
+    }
+
+    render(<Component />);
+
+    expect(spy).toHaveBeenCalledTimes(5);
+
+    newTasks = [task3, task1, task2, task5, task4];
+    await user.click(screen.getByRole("button", { name: "Change tasks" }));
+
+    expect(spy).toHaveBeenCalledTimes(5);
+
+    expect(screen.getByRole("list", { name: "tasks" })).toHaveTextContent(
+      newTasks.map((task, index) => `${index}:${task.content}`).join("")
+    );
+  });
+});

--- a/tests/lucy-state-use-track-value.test.tsx
+++ b/tests/lucy-state-use-track-value.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { useLucyState } from "../src/use-lucy-state";
+
+describe("Lucy Start use track value", () => {
+  it("track value is triggered correctly", async () => {
+    const spy = jest.fn();
+    const user = userEvent.setup();
+
+    let newValue = "new value";
+    function Component() {
+      const state$ = useLucyState("initial value");
+
+      state$.useTrackValue((stateValue) => {
+        spy(stateValue);
+      });
+
+      return (
+        <div>
+          <button onClick={() => state$.setValue(newValue)}>
+            Change value
+          </button>
+        </div>
+      );
+    }
+
+    render(<Component />);
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith("initial value");
+
+    await user.click(screen.getByRole("button", { name: "Change value" }));
+
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(spy).toHaveBeenCalledWith("new value");
+  });
+
+  it("track value can skip the first call", async () => {
+    const spy = jest.fn();
+    const user = userEvent.setup();
+
+    let newValue = "new value";
+    function Component() {
+      const state$ = useLucyState("initial value");
+
+      state$.useTrackValue(
+        (stateValue) => {
+          spy(stateValue);
+        },
+        { skipFirstCall: true }
+      );
+
+      return (
+        <div>
+          <button onClick={() => state$.setValue(newValue)}>
+            Change value
+          </button>
+        </div>
+      );
+    }
+
+    render(<Component />);
+
+    expect(spy).toHaveBeenCalledTimes(0);
+
+    await user.click(screen.getByRole("button", { name: "Change value" }));
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith("new value");
+  });
+});

--- a/tests/lucy-state-value-component.test.tsx
+++ b/tests/lucy-state-value-component.test.tsx
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-import { useLucyState } from "./use-lucy-state";
+import { useLucyState } from "../src/use-lucy-state";
 
 describe("<state$.Value />", () => {
   it("renders the string value if no children are provided", async () => {

--- a/tests/use-lucy-state.test.tsx
+++ b/tests/use-lucy-state.test.tsx
@@ -4,7 +4,7 @@ import { render } from "@testing-library/react";
 import { screen } from "@testing-library/dom";
 import userEvent from "@testing-library/user-event";
 
-import { useLucyState } from "./use-lucy-state";
+import { useLucyState } from "../src/use-lucy-state";
 
 describe("useLucyState", () => {
   it("state works as expected", async () => {


### PR DESCRIPTION
## Description

Add tests for multiple scenarios:

- `<state$.Value />` component
- add tests for expected lists usage
- test `<StableComponent />`
- test `state$.useTrackValue`

I moved them to a separate folder. Similar to [Veles](https://github.com/Bloomca/veles/tree/main/integration-tests), I think it will be easier to test how everything integrates together as opposed to unit tests. E.g. the list functionality consists of several things, imo it doesn't make sense to test just `<StableIteratorComponent />`.