### PR TITLE
add useLucyEffect hook helper

### DIFF
--- a/src/library-connectors/zustand.ts
+++ b/src/library-connectors/zustand.ts
@@ -56,11 +56,11 @@ export function useZustandHook<T, F, A, B, C>({
   }
 
   useEffect(() => {
-    const unsbuscribe = store.subscribe((currentState) => {
+    const unsubscribe = store.subscribe((currentState) => {
       updateStateRef.current(currentState);
     });
 
-    return unsbuscribe;
+    return unsubscribe;
   }, [store, state$]);
 
   useEffect(() => {

--- a/src/utils/use-lucy-effect.test.tsx
+++ b/src/utils/use-lucy-effect.test.tsx
@@ -1,0 +1,108 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { useLucyEffect } from "./use-lucy-effect";
+import { useLucyState } from "../use-lucy-state";
+
+describe("useLucyEffect", () => {
+  it("executes a callback every time a subscribed value changes", async () => {
+    const user = userEvent.setup();
+    const spy = jest.fn();
+    let newValue1 = 5;
+    let newValue2 = 10;
+    let newValue3 = 15;
+    function Component() {
+      const value1$ = useLucyState(1);
+      const value2$ = useLucyState(2);
+      const value3$ = useLucyState(3);
+
+      useLucyEffect(
+        ([]) => {
+          spy();
+        },
+        [value1$, value2$]
+      );
+
+      return (
+        <div>
+          <h3>
+            Value3 is: <value3$.Value />
+          </h3>
+          <button onClick={() => value1$.setValue(newValue1)}>
+            Change value1
+          </button>
+          <button onClick={() => value2$.setValue(newValue2)}>
+            Change value2
+          </button>
+          <button onClick={() => value3$.setValue(newValue3)}>
+            Change value3
+          </button>
+        </div>
+      );
+    }
+
+    render(<Component />);
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    await user.click(screen.getByRole("button", { name: "Change value1" }));
+    expect(spy).toHaveBeenCalledTimes(2);
+
+    await user.click(screen.getByRole("button", { name: "Change value3" }));
+    expect(spy).toHaveBeenCalledTimes(2);
+
+    await user.click(screen.getByRole("button", { name: "Change value2" }));
+    expect(spy).toHaveBeenCalledTimes(3);
+  });
+
+  it("receives correct values in the callback", async () => {
+    const user = userEvent.setup();
+    const spy = jest.fn();
+    let newValue1 = 5;
+    let newValue2 = 10;
+    let newValue3 = 15;
+    function Component() {
+      const value1$ = useLucyState(1);
+      const value2$ = useLucyState(2);
+      const value3$ = useLucyState(3);
+
+      useLucyEffect(
+        ([value1, value2]) => {
+          spy(value1, value2);
+        },
+        [value1$, value2$]
+      );
+
+      return (
+        <div>
+          <h3>
+            Value3 is: <value3$.Value />
+          </h3>
+          <button onClick={() => value1$.setValue(newValue1)}>
+            Change value1
+          </button>
+          <button onClick={() => value2$.setValue(newValue2)}>
+            Change value2
+          </button>
+          <button onClick={() => value3$.setValue(newValue3)}>
+            Change value3
+          </button>
+        </div>
+      );
+    }
+
+    render(<Component />);
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenLastCalledWith(1, 2);
+
+    await user.click(screen.getByRole("button", { name: "Change value1" }));
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(spy).toHaveBeenLastCalledWith(5, 2);
+
+    await user.click(screen.getByRole("button", { name: "Change value3" }));
+    expect(spy).toHaveBeenCalledTimes(2);
+
+    await user.click(screen.getByRole("button", { name: "Change value2" }));
+    expect(spy).toHaveBeenCalledTimes(3);
+    expect(spy).toHaveBeenLastCalledWith(5, 10);
+  });
+});

--- a/src/utils/use-lucy-effect.ts
+++ b/src/utils/use-lucy-effect.ts
@@ -1,0 +1,159 @@
+import { useEffect, useState, useRef } from "react";
+import type { LucyState } from "../types";
+
+function useLucyEffect<A>(
+  cb: (values: [A]) => (() => void) | void,
+  dependencies$: [LucyState<A>]
+): void;
+function useLucyEffect<A, B>(
+  cb: (values: [A, B]) => (() => void) | void,
+  dependencies$: [LucyState<A>, LucyState<B>]
+): void;
+function useLucyEffect<A, B, C>(
+  cb: (values: [A, B, C]) => (() => void) | void,
+  dependencies$: [LucyState<A>, LucyState<B>, LucyState<C>]
+): void;
+function useLucyEffect<A, B, C, D>(
+  cb: (values: [A, B, C, D]) => (() => void) | void,
+  dependencies$: [LucyState<A>, LucyState<B>, LucyState<C>, LucyState<D>]
+): void;
+function useLucyEffect<A, B, C, D, E>(
+  cb: (values: [A, B, C, D, E]) => (() => void) | void,
+  dependencies$: [
+    LucyState<A>,
+    LucyState<B>,
+    LucyState<C>,
+    LucyState<D>,
+    LucyState<E>
+  ]
+): void;
+function useLucyEffect<A, B, C, D, E, F>(
+  cb: (values: [A, B, C, D, E, F]) => (() => void) | void,
+  dependencies$: [
+    LucyState<A>,
+    LucyState<B>,
+    LucyState<C>,
+    LucyState<D>,
+    LucyState<E>,
+    LucyState<F>
+  ]
+): void;
+function useLucyEffect<A, B, C, D, E, F, G>(
+  cb: (values: [A, B, C, D, E, F, G]) => (() => void) | void,
+  dependencies$: [
+    LucyState<A>,
+    LucyState<B>,
+    LucyState<C>,
+    LucyState<D>,
+    LucyState<E>,
+    LucyState<F>,
+    LucyState<G>
+  ]
+): void;
+function useLucyEffect<A, B, C, D, E, F, G, H>(
+  cb: (values: [A, B, C, D, E, F, G, H]) => (() => void) | void,
+  dependencies$: [
+    LucyState<A>,
+    LucyState<B>,
+    LucyState<C>,
+    LucyState<D>,
+    LucyState<E>,
+    LucyState<F>,
+    LucyState<G>,
+    LucyState<H>
+  ]
+): void;
+function useLucyEffect(cb, dependencies$) {
+  const [state, setState] = useState(
+    () => transformState$(dependencies$) as any
+  );
+
+  useEffect(() => {
+    const unsubscribe = cb(state);
+
+    if (unsubscribe) {
+      return unsubscribe;
+    }
+  }, [state]);
+
+  const itemsRef = useRef(dependencies$);
+  const updateStateRef = useRef(null);
+  if (!updateStateRef.current) {
+    updateStateRef.current = () => {
+      setState(transformState$(itemsRef.current) as any);
+    };
+  }
+
+  const unsubscribeRef = useRef<null | (() => void)>(null);
+
+  // to ensure we run the updates function only one time
+  // in case this component re-renders
+  if (unsubscribeRef.current === null) {
+    unsubscribeRef.current = subscribeToUpdates(dependencies$, () => {
+      updateStateRef.current();
+    });
+  }
+
+  useEffect(() => {
+    if (!areArraysEqual(dependencies$, itemsRef.current)) {
+      itemsRef.current = dependencies$;
+      updateStateRef.current();
+
+      if (unsubscribeRef.current) unsubscribeRef.current();
+
+      unsubscribeRef.current = subscribeToUpdates(dependencies$, () => {
+        updateStateRef.current();
+      });
+    }
+  }, [dependencies$]);
+
+  useEffect(() => {
+    return () => {
+      if (unsubscribeRef.current) unsubscribeRef.current();
+    };
+  }, []);
+}
+
+function transformState$(items$: undefined | LucyState<any>[]) {
+  if (!items$) return [];
+  return items$.map((item$) => item$.getValue());
+}
+
+function areArraysEqual(array1: any[] | undefined, array2: any[] | undefined) {
+  // both are undefined
+  if (!array1 && !array2) return true;
+  // if one is undefined, but another is not, we need to recalculate
+  if (!array1 && array2) return false;
+  if (array1 && !array2) return false;
+  if (array1.length !== array2.length) return false;
+
+  for (let i = 0; i < array1.length; i++) {
+    if (array1[i] !== array2[i]) return false;
+  }
+
+  return true;
+}
+
+function subscribeToUpdates(
+  items$: LucyState<any>[] | undefined,
+  onChange: () => void
+) {
+  if (!items$) {
+    return undefined;
+  }
+
+  const unsubscribeFns = [];
+  items$.forEach((item$) => {
+    const unsubscribe = item$.trackValue(() => {
+      onChange();
+    });
+
+    unsubscribeFns.push(unsubscribe);
+  });
+
+  return () => {
+    unsubscribeFns.forEach((fn) => fn());
+  };
+}
+
+export { useLucyEffect };


### PR DESCRIPTION
## Description

Add `useLucyEffect` helper, so that you don't need to combine multiple states$ on your own in order to run effects. It allows to go from:

```js
const state1$ = useLucyState(1)
const state2$ = useLucyState(2)
const state3$ = useLucyState(2)

const combinedState$ = combine(state1$, state2$, state3)
combinedState$.useTrackValue(([state1, state2, state3) => {
  // ....
})
```

to skip the combine step completely:

```js
const state1$ = useLucyState(1)
const state2$ = useLucyState(2)
const state3$ = useLucyState(2)

useLucyEffect(([state1, state2, state3) => {
  // ....
}, [state1$, state2$, state3$])
```