### PR TITLE
Add stable item component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-lucy-state",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-lucy-state",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "MIT",
       "devDependencies": {
         "@testing-library/dom": "^10.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-lucy-state",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "More performant replacement for React.useState",
   "type": "module",
   "main": "dist/index.js",

--- a/src/components/stable-item-component.ts
+++ b/src/components/stable-item-component.ts
@@ -4,20 +4,14 @@ import { useConvertToLucyState } from "../convert-into-lucy-state";
 import type { LucyState } from "../types";
 import type { ReactNode } from "react";
 
-function _StableIteratorComponent<T>({
+function _StableItemComponent<T>({
   item,
-  index,
   children,
 }: {
   item: T;
-  index: number;
-  children: (
-    itemState: LucyState<T>,
-    indexState: LucyState<number>
-  ) => ReactNode;
+  children: (itemState: LucyState<T>) => ReactNode;
 }) {
   const itemState = useConvertToLucyState(item);
-  const indexState = useConvertToLucyState(index);
 
   const nodeRef = useRef<{ initialized: boolean; markup: ReactNode }>({
     initialized: false,
@@ -27,7 +21,7 @@ function _StableIteratorComponent<T>({
   if (nodeRef.current.initialized === false) {
     nodeRef.current = {
       initialized: true,
-      markup: children(itemState, indexState),
+      markup: children(itemState),
     };
   }
 
@@ -37,11 +31,10 @@ function _StableIteratorComponent<T>({
 }
 
 // @ts-expect-error types are the same
-export const StableIteratorComponent: typeof _StableIteratorComponent = memo(
-  _StableIteratorComponent,
+export const StableItemComponent: typeof _StableItemComponent = memo(
+  _StableItemComponent,
   (prevProps, newProps) => {
-    return (
-      prevProps.item === newProps.item && prevProps.index === newProps.item
-    );
+    // only item can change, we ignore the children callback
+    return prevProps.item === newProps.item;
   }
 );

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ export {
 
 export { UnstableComponent } from "./components/unstable-component";
 export { StableComponent } from "./components/stable-component";
+export { StableItemComponent } from "./components/stable-item-component";
 export { StableIteratorComponent } from "./components/stable-iterator-component";
 
 export type { LucyState } from "./types";

--- a/tests/lucy-state-list.test.tsx
+++ b/tests/lucy-state-list.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { StableIteratorComponent } from "../src/components/stable-iterator-component";
+import { StableItemComponent } from "../src/components/stable-item-component";
 import { useLucyState } from "../src/use-lucy-state";
 
 import type { LucyState } from "../src/types";
@@ -44,6 +45,68 @@ describe("Lucy State lists", () => {
                   >
                     {(task$) => <ItemComponent task$={task$} />}
                   </StableIteratorComponent>
+                ))
+              }
+            </tasks$.Value>
+          </ul>
+          <button onClick={() => tasks$.setValue(newTasks)}>
+            Change tasks
+          </button>
+        </div>
+      );
+    }
+
+    render(<Component />);
+
+    expect(spy).toHaveBeenCalledTimes(5);
+
+    newTasks = [
+      task1,
+      task2,
+      { id: 3, content: "new task 3 content" },
+      task4,
+      task5,
+    ];
+    await user.click(screen.getByRole("button", { name: "Change tasks" }));
+
+    // just checking that nothing remounted; the components are stable and won't re-render
+    expect(spy).toHaveBeenCalledTimes(5);
+
+    expect(screen.getByRole("list", { name: "tasks" })).toHaveTextContent(
+      newTasks.map((task) => task.content).join("")
+    );
+  });
+
+  it("only re-renders list items which changed when using <StableItemComponent />", async () => {
+    const user = userEvent.setup();
+    const spy = jest.fn();
+    const task1: Task = { id: 1, content: "First task" };
+    const task2: Task = { id: 2, content: "Second task" };
+    const task3: Task = { id: 3, content: "Third task" };
+    const task4: Task = { id: 4, content: "Fourth task" };
+    const task5: Task = { id: 5, content: "Fifth task" };
+    let newTasks: Task[] = [];
+    function ItemComponent({ task$ }: { task$: LucyState<Task> }) {
+      useEffect(spy);
+
+      return (
+        <li>
+          <task$.Value selector={(task) => task.content} />
+        </li>
+      );
+    }
+    function Component() {
+      const tasks$ = useLucyState([task1, task2, task3, task4, task5]);
+
+      return (
+        <div>
+          <ul aria-label="tasks">
+            <tasks$.Value>
+              {(tasks) =>
+                tasks.map((task) => (
+                  <StableItemComponent item={task} key={task.id}>
+                    {(task$) => <ItemComponent task$={task$} />}
+                  </StableItemComponent>
                 ))
               }
             </tasks$.Value>


### PR DESCRIPTION
## Description

While playing around in a test project, I realized two things.

First, it is not exactly cheap to re-render components even if they don't really render anything, I guess the lifecycle is expensive. Because of that, `<StableIteratorComponent` gets a custom memo wrapper, and I also add a `<StableItemComponent` which is the same component, but is not listening to index (so no re-renders if items are just moved around).