### PR TITLE
add prepublish script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-lucy-state",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-lucy-state",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "license": "MIT",
       "devDependencies": {
         "@testing-library/dom": "^10.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-lucy-state",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "More performant replacement for React.useState",
   "type": "module",
   "main": "dist/index.js",
@@ -18,7 +18,8 @@
   },
   "scripts": {
     "test": "jest",
-    "build": "tsup"
+    "build": "tsup",
+    "prepublishOnly": "npm run build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description

For `0.0.2`, I forgot to run `npm run build`, so the new version wasn't uploaded.

I need to look deeper into this, maybe I can just deliver source code and let bundlers deal with it, but for now I'll use this.