### PR TITLE
add an option to pass a function to set lucy state

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ function Component() {
 
   return (
     <div>
-      <button onClick={() => counter$.setValue(counter$.getValue() + 1)}>
+      <button onClick={() => counter$.setValue((value) => value + 1)}>
         Increment counter
       </button>
     </div>
@@ -202,7 +202,7 @@ function Component() {
 
   return (
     <div>
-      <button onClick={() => value$.setValue(value$.getValue() + 1)}>
+      <button onClick={() => value$.setValue((value) => value + 1)}>
         Increment value
       </button>
       <Content value$={value$} />

--- a/src/create-lucy-state.test.ts
+++ b/src/create-lucy-state.test.ts
@@ -27,4 +27,28 @@ describe("createLucyState", () => {
       expect(spy).not.toHaveBeenCalledWith(3);
     });
   });
+
+  it("support initial value set as a function", () => {
+    const state$ = createLucyState(() => 1);
+
+    expect(state$.getValue()).toBe(1);
+  });
+
+  it("receives current value as a first argument if passed a function to setValue", () => {
+    const spy = jest.fn();
+    const state$ = createLucyState(1);
+    state$.setValue((currentValue) => {
+      spy(currentValue);
+      return 2;
+    });
+
+    expect(spy).toHaveBeenLastCalledWith(1);
+
+    state$.setValue((currentValue) => {
+      spy(currentValue);
+      return 3;
+    });
+
+    expect(spy).toHaveBeenLastCalledWith(2);
+  });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 export { useLucyState } from "./use-lucy-state";
 export { useCombine$ } from "./utils/combine";
 export { useSelect$ } from "./utils/select";
+export { useReduce$ } from "./utils/reduce";
 export {
   useConvertToLucyState,
   useConvertLucyStateToProperty,

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -2,7 +2,7 @@ import React from "react";
 
 export type LucyState<T> = {
   getValue: () => T;
-  setValue: (newValue: T) => void;
+  setValue: (newValue: T | ((currentValue: T) => T)) => void;
   Value: <F = T>({
     selector,
     children,

--- a/src/use-lucy-state.ts
+++ b/src/use-lucy-state.ts
@@ -4,14 +4,8 @@ import { createLucyState } from "./create-lucy-state";
 type createdState<StateType> = ReturnType<typeof createLucyState<StateType>>;
 
 export function useLucyState<T>(
-  initialValue: T,
-  {
-    subscribeCallback,
-    comparator,
-  }: {
-    subscribeCallback?: (setValue: (newValue: T) => void) => Function;
-    comparator?: (a: T, b: T) => boolean;
-  } = {}
+  initialValue: T | (() => T),
+  comparator?: (a: T, b: T) => boolean
 ) {
   const initStateRef = useRef<null | createdState<T>>(null);
 
@@ -21,17 +15,6 @@ export function useLucyState<T>(
   }
 
   const lucyStateRef = useRef(initStateRef.current);
-
-  useEffect(() => {
-    if (subscribeCallback) {
-      const unsubscribe = subscribeCallback(lucyStateRef.current.setValue);
-
-      return () => unsubscribe();
-    }
-    // ideally we'd want to have the callback which never changes
-    // otherwise it will change on every re-render, which will cause constant
-    // registering/de-registering
-  }, [subscribeCallback]);
 
   return lucyStateRef.current;
 }

--- a/src/utils/combine.ts
+++ b/src/utils/combine.ts
@@ -75,8 +75,9 @@ export function useCombine$<A, B, C, D, E, F, G, H, I, J>(
   state10: createdState<J>
 ): createdState<[A, B, C, D, E, F, G, H, I, J]>;
 export function useCombine$(...states) {
-  const initialValue = states.map((state) => state.getValue());
-  const combinedState = useLucyState(initialValue);
+  const combinedState = useLucyState(() =>
+    states.map((state) => state.getValue())
+  );
 
   states.forEach((state) => {
     state.useTrackValue(

--- a/src/utils/select.ts
+++ b/src/utils/select.ts
@@ -6,9 +6,7 @@ function useSelect$<F, T>(
   state: State<F>,
   selector: (state: F) => T
 ): State<T> {
-  const initialValue = selector(state.getValue());
-
-  const newState = useLucyState(initialValue);
+  const newState = useLucyState(() => selector(state.getValue()));
   state.useTrackValueSelector(
     selector,
     (selectedState) => {


### PR DESCRIPTION
## Reference

Add an option to pass a function to initialize new Lucy state, and also pass a function to `setValue` to receive current value. Mostly syntactic sugar, although the initialization part can be handy to avoid some expensive calculations.