### PR TITLE
split getter and setter for LucyState

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Let's see a simple example, a value from input saved to a variable and reflected
 import { useLucyState } from "react-lucy-state";
 
 function MyComponent() {
-  const inputValue$ = useLucyState("");
+  const [inputValue$, setInputValue] = useLucyState("");
 
   return (
     <div>
@@ -25,7 +25,7 @@ function MyComponent() {
           <input
             type="text"
             value={value}
-            onChange={(e) => inputValue$.setValue(e.target.value)}
+            onChange={(e) => setInputValue(e.target.value)}
           />
         )}
       </inputValue$.Value>
@@ -107,7 +107,7 @@ import {
 } from "react-lucy-state";
 
 function Component() {
-  const input$ = useLucyState("");
+  const [input$, setInput] = useLucyState("");
   // we check if the value contains only numbers
   const hasError$ = useSelect$(input$, (value) => !value.match(/^[0-9]+$/i));
 
@@ -128,7 +128,7 @@ function Component() {
           <input
             type="text"
             value={value}
-            onChange={(e) => input$.setValue(e.target.value)}
+            onChange={(e) => setInput(e.target.value)}
           />
         )}
       </input$.Value>
@@ -145,7 +145,7 @@ LucyState provides a `useTrackValue` and `useTrackValueSelector` methods, which 
 import { useLucyState } from "react-lucy-state";
 
 function Component() {
-  const counter$ = useLucyState(0);
+  const [counter$, setCounter] = useLucyState(0);
 
   counter$.useTrackValue((counterValue) => {
     console.log(`counter value is ${counterValue}`);
@@ -153,7 +153,7 @@ function Component() {
 
   return (
     <div>
-      <button onClick={() => counter$.setValue((value) => value + 1)}>
+      <button onClick={() => setCounter((value) => value + 1)}>
         Increment counter
       </button>
     </div>
@@ -167,8 +167,8 @@ Similar to `React.useEffect`, you can return a function, which will be executed 
 import { useLucyState, useCombine$ } from "react-lucy-state";
 
 function Component() {
-  const firstCounter$ = useLucyState(0);
-  const secondCounter$ = useLucyState(0);
+  const [firstCounter$, setFirstCounter] = useLucyState(0);
+  const [secondCounter$, setSecondCounter] = useLucyState(0);
 
   const combinedCounter$ = useCombine$(firstCounter$, secondCounter$);
   combinedCounter$.useTrackValue(([firstValue, secondValue]) => {
@@ -177,14 +177,10 @@ function Component() {
 
   return (
     <div>
-      <button
-        onClick={() => firstCounter$.setValue(firstCounter$.getValue() + 1)}
-      >
+      <button onClick={() => setFirstCounter(firstCounter$.getValue() + 1)}>
         Increment first counter
       </button>
-      <button
-        onClick={() => secondCounter$.setValue(secondCounter$.getValue() + 1)}
-      >
+      <button onClick={() => setSecondCounter(secondCounter$.getValue() + 1)}>
         Increment second counter
       </button>
     </div>
@@ -198,11 +194,11 @@ You can switch back and forth between regular props and Lucy state, but you shou
 
 ```jsx
 function Component() {
-  const value$ = useLucyState(0);
+  const [value$, setValue] = useLucyState(0);
 
   return (
     <div>
-      <button onClick={() => value$.setValue((value) => value + 1)}>
+      <button onClick={() => setValue((value) => value + 1)}>
         Increment value
       </button>
       <Content value$={value$} />

--- a/src/components/stable-item-component.ts
+++ b/src/components/stable-item-component.ts
@@ -11,7 +11,7 @@ function _StableItemComponent<T>({
   item: T;
   children: (itemState: LucyState<T>) => ReactNode;
 }) {
-  const itemState = useConvertToLucyState(item);
+  const item$ = useConvertToLucyState(item);
 
   const nodeRef = useRef<{ initialized: boolean; markup: ReactNode }>({
     initialized: false,
@@ -21,7 +21,7 @@ function _StableItemComponent<T>({
   if (nodeRef.current.initialized === false) {
     nodeRef.current = {
       initialized: true,
-      markup: children(itemState),
+      markup: children(item$),
     };
   }
 

--- a/src/components/stable-iterator-component.ts
+++ b/src/components/stable-iterator-component.ts
@@ -16,8 +16,8 @@ function _StableIteratorComponent<T>({
     indexState: LucyState<number>
   ) => ReactNode;
 }) {
-  const itemState = useConvertToLucyState(item);
-  const indexState = useConvertToLucyState(index);
+  const item$ = useConvertToLucyState(item);
+  const index$ = useConvertToLucyState(index);
 
   const nodeRef = useRef<{ initialized: boolean; markup: ReactNode }>({
     initialized: false,
@@ -27,7 +27,7 @@ function _StableIteratorComponent<T>({
   if (nodeRef.current.initialized === false) {
     nodeRef.current = {
       initialized: true,
-      markup: children(itemState, indexState),
+      markup: children(item$, index$),
     };
   }
 

--- a/src/components/unstable-component.test.tsx
+++ b/src/components/unstable-component.test.tsx
@@ -16,13 +16,11 @@ describe("<UnstableComponent />", () => {
       return <h1>{value}</h1>;
     }
     function Component() {
-      const state$ = useLucyState("first value");
+      const [state$, setState] = useLucyState("first value");
 
       return (
         <div>
-          <button onClick={() => state$.setValue(newValue)}>
-            Change value
-          </button>
+          <button onClick={() => setState(newValue)}>Change value</button>
           <UnstableComponent items$={[state$]}>
             {(items) => <Content value={items[0]} />}
           </UnstableComponent>
@@ -65,17 +63,15 @@ describe("<UnstableComponent />", () => {
       return <h1 aria-label={label}>{`name is ${name}, and age is ${age}`}</h1>;
     }
     function Component() {
-      const name$ = useLucyState("Initial name");
-      const age$ = useLucyState(25);
-      const label$ = useLucyState("credentials");
+      const [name$, setName] = useLucyState("Initial name");
+      const [age$, setAge] = useLucyState(25);
+      const [label$, setLabel] = useLucyState("credentials");
 
       return (
         <div>
-          <button onClick={() => name$.setValue(newName)}>Change name</button>
-          <button onClick={() => age$.setValue(newAge)}>Change age</button>
-          <button onClick={() => label$.setValue(newLabel)}>
-            Change label
-          </button>
+          <button onClick={() => setName(newName)}>Change name</button>
+          <button onClick={() => setAge(newAge)}>Change age</button>
+          <button onClick={() => setLabel(newLabel)}>Change label</button>
           <UnstableComponent items$={[name$, age$, label$]}>
             {([name, age, label]) => {
               return <Content name={name} age={age} label={label} />;

--- a/src/convert-into-lucy-state.test.tsx
+++ b/src/convert-into-lucy-state.test.tsx
@@ -16,11 +16,11 @@ describe("React interop", () => {
     it("converts the state and updates the value correctly", async () => {
       const user = userEvent.setup();
       function Component() {
-        const value$ = useLucyState(0);
+        const [value$, setValue] = useLucyState(0);
 
         return (
           <div>
-            <button onClick={() => value$.setValue(value$.getValue() + 1)}>
+            <button onClick={() => setValue((value) => value + 1)}>
               Increment value
             </button>
             <Content value$={value$} />

--- a/src/convert-into-lucy-state.ts
+++ b/src/convert-into-lucy-state.ts
@@ -7,13 +7,13 @@ import type { LucyState } from "./types";
 // same data structure, it won't give you performance benefits,
 // because it will cause cascade re-renders
 export function useConvertToLucyState<T>(property: T) {
-  const state = useLucyState(property);
+  const [state$, setState] = useLucyState(property);
 
   useEffect(() => {
-    state.setValue(property);
-  }, [property, state]);
+    setState(property);
+  }, [property, setState]);
 
-  return state;
+  return state$;
 }
 
 export function useConvertLucyStateToProperty<T>(lucyState: LucyState<T>) {

--- a/src/create-lucy-state.test.ts
+++ b/src/create-lucy-state.test.ts
@@ -4,12 +4,12 @@ describe("createLucyState", () => {
   describe("trackValue", () => {
     it("calls when the value updates correctly", () => {
       const spy = jest.fn();
-      const state$ = createLucyState(1);
+      const [state$, setState] = createLucyState(1);
       state$.trackValue(spy);
 
       expect(spy).not.toHaveBeenCalled();
 
-      state$.setValue(2);
+      setState(2);
 
       expect(spy).toHaveBeenCalledTimes(1);
       expect(spy).toHaveBeenCalledWith(2);
@@ -17,11 +17,11 @@ describe("createLucyState", () => {
 
     it("unsubscribes correctly", () => {
       const spy = jest.fn();
-      const state$ = createLucyState(1);
+      const [state$, setState] = createLucyState(1);
       const unsubscribe = state$.trackValue(spy);
-      state$.setValue(2);
+      setState(2);
       unsubscribe();
-      state$.setValue(3);
+      setState(3);
 
       expect(spy).toHaveBeenCalledTimes(1);
       expect(spy).not.toHaveBeenCalledWith(3);
@@ -29,22 +29,22 @@ describe("createLucyState", () => {
   });
 
   it("support initial value set as a function", () => {
-    const state$ = createLucyState(() => 1);
+    const [state$] = createLucyState(() => 1);
 
     expect(state$.getValue()).toBe(1);
   });
 
   it("receives current value as a first argument if passed a function to setValue", () => {
     const spy = jest.fn();
-    const state$ = createLucyState(1);
-    state$.setValue((currentValue) => {
+    const [_state$, setState] = createLucyState(1);
+    setState((currentValue) => {
       spy(currentValue);
       return 2;
     });
 
     expect(spy).toHaveBeenLastCalledWith(1);
 
-    state$.setValue((currentValue) => {
+    setState((currentValue) => {
       spy(currentValue);
       return 3;
     });
@@ -54,22 +54,22 @@ describe("createLucyState", () => {
 
   it("supports comparator", () => {
     const spy1 = jest.fn();
-    const state1$ = createLucyState({ prop: 1 });
+    const [state1$, setState1] = createLucyState({ prop: 1 });
 
     state1$.trackValue(spy1);
 
-    state1$.setValue({ prop: 1 });
+    setState1({ prop: 1 });
     expect(spy1).toHaveBeenCalledTimes(1);
 
     const spy2 = jest.fn();
-    const state2$ = createLucyState(
+    const [state2$, setState2] = createLucyState(
       { prop: 1 },
       (prevState, nextState) => prevState.prop === nextState.prop
     );
 
     state2$.trackValue(spy2);
 
-    state2$.setValue({ prop: 1 });
+    setState2({ prop: 1 });
     expect(spy2).toHaveBeenCalledTimes(0);
   });
 });

--- a/src/library-connectors/redux.ts
+++ b/src/library-connectors/redux.ts
@@ -4,16 +4,16 @@ import { useLucyState } from "../use-lucy-state";
 
 export function useReduxHook<T, F>(selector: (state: T) => F) {
   const store = useStore<T>();
-  const state = useLucyState(selector(store.getState()));
+  const [state$, setState] = useLucyState(selector(store.getState()));
 
   useEffect(() => {
     const unsbuscribe = store.subscribe(() => {
       const newValue = selector(store.getState());
-      state.setValue(newValue);
+      setState(newValue);
     });
 
     return unsbuscribe;
-  }, [store, state]);
+  }, [store, setState]);
 
-  return state;
+  return state$;
 }

--- a/src/library-connectors/zustand.test.tsx
+++ b/src/library-connectors/zustand.test.tsx
@@ -170,7 +170,7 @@ describe("useZustandHook", () => {
     }));
 
     function Component() {
-      const select$ = useLucyState("first");
+      const [select$, setSelection] = useLucyState("first");
       const zustand$ = useZustandHook({
         store: zustandStore,
         selector: (state, [selection]) => state.value[selection],
@@ -182,7 +182,7 @@ describe("useZustandHook", () => {
           <h2>
             Current value is: <zustand$.Value />
           </h2>
-          <button onClick={() => select$.setValue(newSelection)}>
+          <button onClick={() => setSelection(newSelection)}>
             Change selection
           </button>
           <button onClick={() => zustandStore.getState().updateValue()}>

--- a/src/library-connectors/zustand.ts
+++ b/src/library-connectors/zustand.ts
@@ -31,7 +31,7 @@ export function useZustandHook<T, F, A, B, C>({
       transformState$(dependencies$) as any
     );
   }
-  const state$ = useLucyState(firstValue.current);
+  const [state$, setState] = useLucyState(firstValue.current);
   const itemsRef = useRef(dependencies$);
 
   const updateStateRef = useRef(null);
@@ -41,7 +41,7 @@ export function useZustandHook<T, F, A, B, C>({
         currentStoreState,
         transformState$(itemsRef.current) as any
       );
-      state$.setValue(newValue);
+      setState(newValue);
     };
   }
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -2,7 +2,6 @@ import React from "react";
 
 export type LucyState<T> = {
   getValue: () => T;
-  setValue: (newValue: T | ((currentValue: T) => T)) => void;
   Value: <F = T>({
     selector,
     children,
@@ -27,3 +26,7 @@ export type LucyState<T> = {
   ): void;
   trackValue(cb: (value: T) => void | Function): () => void;
 };
+
+export function SetState<T>(newValue: T | ((currentValue: T) => T)): void;
+
+export type LucyRef<T> = [LucyState<T>, typeof SetState<T>];

--- a/src/use-lucy-state.ts
+++ b/src/use-lucy-state.ts
@@ -1,4 +1,4 @@
-import { useRef, useEffect } from "react";
+import { useRef } from "react";
 import { createLucyState } from "./create-lucy-state";
 
 type createdState<StateType> = ReturnType<typeof createLucyState<StateType>>;
@@ -14,7 +14,5 @@ export function useLucyState<T>(
     initStateRef.current = createLucyState(initialValue, comparator);
   }
 
-  const lucyStateRef = useRef(initStateRef.current);
-
-  return lucyStateRef.current;
+  return initStateRef.current;
 }

--- a/src/utils/combine.ts
+++ b/src/utils/combine.ts
@@ -1,81 +1,81 @@
 import { useLucyState } from "../use-lucy-state";
 
-type createdState<StateType> = ReturnType<typeof useLucyState<StateType>>;
+import { LucyState } from "../types";
 
 export function useCombine$<A, B>(
-  state1: createdState<A>,
-  state2: createdState<B>
-): createdState<[A, B]>;
+  state1: LucyState<A>,
+  state2: LucyState<B>
+): LucyState<[A, B]>;
 export function useCombine$<A, B, C>(
-  state1: createdState<A>,
-  state2: createdState<B>,
-  state3: createdState<C>
-): createdState<[A, B, C]>;
+  state1: LucyState<A>,
+  state2: LucyState<B>,
+  state3: LucyState<C>
+): LucyState<[A, B, C]>;
 export function useCombine$<A, B, C, D>(
-  state1: createdState<A>,
-  state2: createdState<B>,
-  state3: createdState<C>,
-  state4: createdState<D>
-): createdState<[A, B, C, D]>;
+  state1: LucyState<A>,
+  state2: LucyState<B>,
+  state3: LucyState<C>,
+  state4: LucyState<D>
+): LucyState<[A, B, C, D]>;
 export function useCombine$<A, B, C, D, E>(
-  state1: createdState<A>,
-  state2: createdState<B>,
-  state3: createdState<C>,
-  state4: createdState<D>,
-  state5: createdState<E>
-): createdState<[A, B, C, D, E]>;
+  state1: LucyState<A>,
+  state2: LucyState<B>,
+  state3: LucyState<C>,
+  state4: LucyState<D>,
+  state5: LucyState<E>
+): LucyState<[A, B, C, D, E]>;
 export function useCombine$<A, B, C, D, E, F>(
-  state1: createdState<A>,
-  state2: createdState<B>,
-  state3: createdState<C>,
-  state4: createdState<D>,
-  state5: createdState<E>,
-  state6: createdState<F>
-): createdState<[A, B, C, D, E, F]>;
+  state1: LucyState<A>,
+  state2: LucyState<B>,
+  state3: LucyState<C>,
+  state4: LucyState<D>,
+  state5: LucyState<E>,
+  state6: LucyState<F>
+): LucyState<[A, B, C, D, E, F]>;
 export function useCombine$<A, B, C, D, E, F, G>(
-  state1: createdState<A>,
-  state2: createdState<B>,
-  state3: createdState<C>,
-  state4: createdState<D>,
-  state5: createdState<E>,
-  state6: createdState<F>,
-  state7: createdState<G>
-): createdState<[A, B, C, D, E, F, G]>;
+  state1: LucyState<A>,
+  state2: LucyState<B>,
+  state3: LucyState<C>,
+  state4: LucyState<D>,
+  state5: LucyState<E>,
+  state6: LucyState<F>,
+  state7: LucyState<G>
+): LucyState<[A, B, C, D, E, F, G]>;
 export function useCombine$<A, B, C, D, E, F, G, H>(
-  state1: createdState<A>,
-  state2: createdState<B>,
-  state3: createdState<C>,
-  state4: createdState<D>,
-  state5: createdState<E>,
-  state6: createdState<F>,
-  state7: createdState<G>,
-  state8: createdState<H>
-): createdState<[A, B, C, D, E, F, G, H]>;
+  state1: LucyState<A>,
+  state2: LucyState<B>,
+  state3: LucyState<C>,
+  state4: LucyState<D>,
+  state5: LucyState<E>,
+  state6: LucyState<F>,
+  state7: LucyState<G>,
+  state8: LucyState<H>
+): LucyState<[A, B, C, D, E, F, G, H]>;
 export function useCombine$<A, B, C, D, E, F, G, H, I>(
-  state1: createdState<A>,
-  state2: createdState<B>,
-  state3: createdState<C>,
-  state4: createdState<D>,
-  state5: createdState<E>,
-  state6: createdState<F>,
-  state7: createdState<G>,
-  state8: createdState<H>,
-  state9: createdState<I>
-): createdState<[A, B, C, D, E, F, G, H, I]>;
+  state1: LucyState<A>,
+  state2: LucyState<B>,
+  state3: LucyState<C>,
+  state4: LucyState<D>,
+  state5: LucyState<E>,
+  state6: LucyState<F>,
+  state7: LucyState<G>,
+  state8: LucyState<H>,
+  state9: LucyState<I>
+): LucyState<[A, B, C, D, E, F, G, H, I]>;
 export function useCombine$<A, B, C, D, E, F, G, H, I, J>(
-  state1: createdState<A>,
-  state2: createdState<B>,
-  state3: createdState<C>,
-  state4: createdState<D>,
-  state5: createdState<E>,
-  state6: createdState<F>,
-  state7: createdState<G>,
-  state8: createdState<H>,
-  state9: createdState<I>,
-  state10: createdState<J>
-): createdState<[A, B, C, D, E, F, G, H, I, J]>;
+  state1: LucyState<A>,
+  state2: LucyState<B>,
+  state3: LucyState<C>,
+  state4: LucyState<D>,
+  state5: LucyState<E>,
+  state6: LucyState<F>,
+  state7: LucyState<G>,
+  state8: LucyState<H>,
+  state9: LucyState<I>,
+  state10: LucyState<J>
+): LucyState<[A, B, C, D, E, F, G, H, I, J]>;
 export function useCombine$(...states) {
-  const combinedState = useLucyState(() =>
+  const [combinedState$, setCombinedState] = useLucyState(() =>
     states.map((state) => state.getValue())
   );
 
@@ -86,11 +86,11 @@ export function useCombine$(...states) {
         // it is guaranteed that reading `state.getValue` will
         // return the updated value
         const updatedValue = states.map((state) => state.getValue());
-        combinedState.setValue(updatedValue);
+        setCombinedState(updatedValue);
       },
       { skipFirstCall: true }
     );
   });
 
-  return combinedState;
+  return combinedState$;
 }

--- a/src/utils/select.ts
+++ b/src/utils/select.ts
@@ -1,22 +1,24 @@
 import { useLucyState } from "../use-lucy-state";
 
-type State<StateType> = ReturnType<typeof useLucyState<StateType>>;
+import type { LucyState } from "../types";
 
 function useSelect$<F, T>(
-  state: State<F>,
+  state: LucyState<F>,
   selector: (state: F) => T,
   comparator?: (previousSelectedState: T, nextSelectedState: T) => boolean
-): State<T> {
-  const newState = useLucyState(() => selector(state.getValue()));
+): LucyState<T> {
+  const [newState$, setNewState] = useLucyState(() =>
+    selector(state.getValue())
+  );
   state.useTrackValueSelector(
     selector,
     (selectedState) => {
-      newState.setValue(selectedState);
+      setNewState(selectedState);
     },
     { skipFirstCall: true, comparator }
   );
 
-  return newState;
+  return newState$;
 }
 
 export { useSelect$ };

--- a/src/utils/use-lucy-effect.test.tsx
+++ b/src/utils/use-lucy-effect.test.tsx
@@ -12,9 +12,9 @@ describe("useLucyEffect", () => {
     let newValue2 = 10;
     let newValue3 = 15;
     function Component() {
-      const value1$ = useLucyState(1);
-      const value2$ = useLucyState(2);
-      const value3$ = useLucyState(3);
+      const [value1$, setValue1] = useLucyState(1);
+      const [value2$, setValue2] = useLucyState(2);
+      const [value3$, setValue3] = useLucyState(3);
 
       useLucyEffect(
         ([]) => {
@@ -28,15 +28,9 @@ describe("useLucyEffect", () => {
           <h3>
             Value3 is: <value3$.Value />
           </h3>
-          <button onClick={() => value1$.setValue(newValue1)}>
-            Change value1
-          </button>
-          <button onClick={() => value2$.setValue(newValue2)}>
-            Change value2
-          </button>
-          <button onClick={() => value3$.setValue(newValue3)}>
-            Change value3
-          </button>
+          <button onClick={() => setValue1(newValue1)}>Change value1</button>
+          <button onClick={() => setValue2(newValue2)}>Change value2</button>
+          <button onClick={() => setValue3(newValue3)}>Change value3</button>
         </div>
       );
     }
@@ -61,9 +55,9 @@ describe("useLucyEffect", () => {
     let newValue2 = 10;
     let newValue3 = 15;
     function Component() {
-      const value1$ = useLucyState(1);
-      const value2$ = useLucyState(2);
-      const value3$ = useLucyState(3);
+      const [value1$, setValue1] = useLucyState(1);
+      const [value2$, setValue2] = useLucyState(2);
+      const [value3$, setValue3] = useLucyState(3);
 
       useLucyEffect(
         ([value1, value2]) => {
@@ -77,15 +71,9 @@ describe("useLucyEffect", () => {
           <h3>
             Value3 is: <value3$.Value />
           </h3>
-          <button onClick={() => value1$.setValue(newValue1)}>
-            Change value1
-          </button>
-          <button onClick={() => value2$.setValue(newValue2)}>
-            Change value2
-          </button>
-          <button onClick={() => value3$.setValue(newValue3)}>
-            Change value3
-          </button>
+          <button onClick={() => setValue1(newValue1)}>Change value1</button>
+          <button onClick={() => setValue2(newValue2)}>Change value2</button>
+          <button onClick={() => setValue3(newValue3)}>Change value3</button>
         </div>
       );
     }

--- a/src/utils/utils.test.tsx
+++ b/src/utils/utils.test.tsx
@@ -13,8 +13,8 @@ describe("utility functions", () => {
       let newValue1 = 5;
       let newValue2 = "Updated value";
       function Component() {
-        const value1$ = useLucyState(0);
-        const value2$ = useLucyState("Initial value");
+        const [value1$, setValue1] = useLucyState(0);
+        const [value2$, setValue2] = useLucyState("Initial value");
 
         const combinedValue$ = useReduce$(
           [value1$, value2$],
@@ -25,12 +25,8 @@ describe("utility functions", () => {
 
         return (
           <div>
-            <button onClick={() => value1$.setValue(newValue1)}>
-              Change value1
-            </button>
-            <button onClick={() => value2$.setValue(newValue2)}>
-              Change value2
-            </button>
+            <button onClick={() => setValue1(newValue1)}>Change value1</button>
+            <button onClick={() => setValue2(newValue2)}>Change value2</button>
           </div>
         );
       }
@@ -60,8 +56,8 @@ describe("utility functions", () => {
         thirdValue: "and even more",
       };
       function Component() {
-        const state$ = useLucyState(state);
-        const value$ = useLucyState(0);
+        const [state$, setState] = useLucyState(state);
+        const [value$, setValue] = useLucyState(0);
 
         const reducedValue$ = useReduce$(
           [state$, value$],
@@ -80,10 +76,10 @@ describe("utility functions", () => {
 
         return (
           <div>
-            <button onClick={() => value$.setValue((value) => value + 1)}>
+            <button onClick={() => setValue((value) => value + 1)}>
               Increment
             </button>
-            <button onClick={() => state$.setValue(state)}>Update state</button>
+            <button onClick={() => setState(state)}>Update state</button>
           </div>
         );
       }
@@ -112,7 +108,7 @@ describe("utility functions", () => {
       const spy = jest.fn();
       const user = userEvent.setup();
       function Component() {
-        const value$ = useLucyState(0);
+        const [value$, setValue] = useLucyState(0);
         const valueWithStep$ = useSelect$(
           value$,
           (value) => value,
@@ -123,7 +119,7 @@ describe("utility functions", () => {
 
         return (
           <div>
-            <button onClick={() => value$.setValue((value) => value + 1)}>
+            <button onClick={() => setValue((value) => value + 1)}>
               Increment
             </button>
             <h2>

--- a/tests/lucy-state-list.test.tsx
+++ b/tests/lucy-state-list.test.tsx
@@ -30,7 +30,13 @@ describe("Lucy State lists", () => {
       );
     }
     function Component() {
-      const tasks$ = useLucyState([task1, task2, task3, task4, task5]);
+      const [tasks$, setTasks] = useLucyState([
+        task1,
+        task2,
+        task3,
+        task4,
+        task5,
+      ]);
 
       return (
         <div>
@@ -49,9 +55,7 @@ describe("Lucy State lists", () => {
               }
             </tasks$.Value>
           </ul>
-          <button onClick={() => tasks$.setValue(newTasks)}>
-            Change tasks
-          </button>
+          <button onClick={() => setTasks(newTasks)}>Change tasks</button>
         </div>
       );
     }
@@ -96,7 +100,13 @@ describe("Lucy State lists", () => {
       );
     }
     function Component() {
-      const tasks$ = useLucyState([task1, task2, task3, task4, task5]);
+      const [tasks$, setTasks] = useLucyState([
+        task1,
+        task2,
+        task3,
+        task4,
+        task5,
+      ]);
 
       return (
         <div>
@@ -111,9 +121,7 @@ describe("Lucy State lists", () => {
               }
             </tasks$.Value>
           </ul>
-          <button onClick={() => tasks$.setValue(newTasks)}>
-            Change tasks
-          </button>
+          <button onClick={() => setTasks(newTasks)}>Change tasks</button>
         </div>
       );
     }
@@ -158,7 +166,13 @@ describe("Lucy State lists", () => {
       );
     }
     function Component() {
-      const tasks$ = useLucyState([task1, task2, task3, task4, task5]);
+      const [tasks$, setTasks] = useLucyState([
+        task1,
+        task2,
+        task3,
+        task4,
+        task5,
+      ]);
 
       return (
         <div>
@@ -177,9 +191,7 @@ describe("Lucy State lists", () => {
               }
             </tasks$.Value>
           </ul>
-          <button onClick={() => tasks$.setValue(newTasks)}>
-            Change tasks
-          </button>
+          <button onClick={() => setTasks(newTasks)}>Change tasks</button>
         </div>
       );
     }
@@ -231,7 +243,13 @@ describe("Lucy State lists", () => {
       );
     }
     function Component() {
-      const tasks$ = useLucyState([task1, task2, task3, task4, task5]);
+      const [tasks$, setTasks] = useLucyState([
+        task1,
+        task2,
+        task3,
+        task4,
+        task5,
+      ]);
 
       return (
         <div>
@@ -252,9 +270,7 @@ describe("Lucy State lists", () => {
               }
             </tasks$.Value>
           </ul>
-          <button onClick={() => tasks$.setValue(newTasks)}>
-            Change tasks
-          </button>
+          <button onClick={() => setTasks(newTasks)}>Change tasks</button>
         </div>
       );
     }

--- a/tests/lucy-state-use-track-value.test.tsx
+++ b/tests/lucy-state-use-track-value.test.tsx
@@ -10,7 +10,7 @@ describe("Lucy Start use track value", () => {
 
     let newValue = "new value";
     function Component() {
-      const state$ = useLucyState("initial value");
+      const [state$, setState] = useLucyState("initial value");
 
       state$.useTrackValue((stateValue) => {
         spy(stateValue);
@@ -18,9 +18,7 @@ describe("Lucy Start use track value", () => {
 
       return (
         <div>
-          <button onClick={() => state$.setValue(newValue)}>
-            Change value
-          </button>
+          <button onClick={() => setState(newValue)}>Change value</button>
         </div>
       );
     }
@@ -42,7 +40,7 @@ describe("Lucy Start use track value", () => {
 
     let newValue = "new value";
     function Component() {
-      const state$ = useLucyState("initial value");
+      const [state$, setState] = useLucyState("initial value");
 
       state$.useTrackValue(
         (stateValue) => {
@@ -53,9 +51,7 @@ describe("Lucy Start use track value", () => {
 
       return (
         <div>
-          <button onClick={() => state$.setValue(newValue)}>
-            Change value
-          </button>
+          <button onClick={() => setState(newValue)}>Change value</button>
         </div>
       );
     }

--- a/tests/lucy-state-value-component.test.tsx
+++ b/tests/lucy-state-value-component.test.tsx
@@ -9,16 +9,14 @@ describe("<state$.Value />", () => {
     const user = userEvent.setup();
     let newValue = "Updated value";
     function Component() {
-      const state$ = useLucyState("Default value");
+      const [state$, setState] = useLucyState("Default value");
 
       return (
         <div>
           <h1>
             <state$.Value />
           </h1>
-          <button onClick={() => state$.setValue(newValue)}>
-            Change value
-          </button>
+          <button onClick={() => setState(newValue)}>Change value</button>
         </div>
       );
     }
@@ -39,16 +37,14 @@ describe("<state$.Value />", () => {
     const user = userEvent.setup();
     let newValue = 20;
     function Component() {
-      const state$ = useLucyState(10);
+      const [state$, setState] = useLucyState(10);
 
       return (
         <div>
           <h1>
             State value is: <state$.Value />
           </h1>
-          <button onClick={() => state$.setValue(newValue)}>
-            Change value
-          </button>
+          <button onClick={() => setState(newValue)}>Change value</button>
         </div>
       );
     }
@@ -69,7 +65,7 @@ describe("<state$.Value />", () => {
     const user = userEvent.setup();
     let newValue = 15;
     function Component() {
-      const state$ = useLucyState(5);
+      const [state$, setState] = useLucyState(5);
 
       return (
         <div>
@@ -77,9 +73,7 @@ describe("<state$.Value />", () => {
             {(value) => <h1>State value is: {value}</h1>}
           </state$.Value>
 
-          <button onClick={() => state$.setValue(newValue)}>
-            Change value
-          </button>
+          <button onClick={() => setState(newValue)}>Change value</button>
         </div>
       );
     }
@@ -103,7 +97,7 @@ describe("<state$.Value />", () => {
       textValue: "New value",
     };
     function Component() {
-      const state$ = useLucyState({
+      const [state$, setState] = useLucyState({
         value: 9,
         textValue: "Initial value",
       });
@@ -114,9 +108,7 @@ describe("<state$.Value />", () => {
             {(value) => <h1>State value is: {value}</h1>}
           </state$.Value>
 
-          <button onClick={() => state$.setValue(newValue)}>
-            Change value
-          </button>
+          <button onClick={() => setState(newValue)}>Change value</button>
         </div>
       );
     }
@@ -146,7 +138,7 @@ describe("<state$.Value />", () => {
       return <h1>State value is: {value}</h1>;
     }
     function Component() {
-      const state$ = useLucyState({
+      const [state$, setState] = useLucyState({
         value: 2,
         textValue: "Initial value",
       });
@@ -157,9 +149,7 @@ describe("<state$.Value />", () => {
             {(value) => <Content value={value} />}
           </state$.Value>
 
-          <button onClick={() => state$.setValue(newValue)}>
-            Change value
-          </button>
+          <button onClick={() => setState(newValue)}>Change value</button>
         </div>
       );
     }
@@ -191,7 +181,7 @@ describe("<state$.Value />", () => {
   it("works with input components as expected", async () => {
     const user = userEvent.setup();
     function Component() {
-      const value$ = useLucyState("");
+      const [value$, setValue] = useLucyState("");
 
       return (
         <div>
@@ -201,7 +191,7 @@ describe("<state$.Value />", () => {
                 type="text"
                 aria-label="valueInput"
                 value={value}
-                onChange={(e) => value$.setValue(e.target.value)}
+                onChange={(e) => setValue(e.target.value)}
               />
             )}
           </value$.Value>

--- a/tests/stable-unstable-components-interop.test.tsx
+++ b/tests/stable-unstable-components-interop.test.tsx
@@ -21,13 +21,11 @@ describe("Interop between <StableComponent> and <UnstableComponent>", () => {
     }
 
     function Component() {
-      const state$ = useLucyState("initialValue");
+      const [state$, setState] = useLucyState("initialValue");
 
       return (
         <div>
-          <button onClick={() => state$.setValue(newValue)}>
-            Change value
-          </button>
+          <button onClick={() => setState(newValue)}>Change value</button>
           <UnstableComponent items$={[state$]}>
             {([value]) => (
               <div aria-label={value}>

--- a/tests/use-lucy-state.test.tsx
+++ b/tests/use-lucy-state.test.tsx
@@ -10,16 +10,14 @@ describe("useLucyState", () => {
   it("state works as expected", async () => {
     const user = userEvent.setup();
     function Component() {
-      const state$ = useLucyState("Initial Value");
+      const [state$, setState] = useLucyState("Initial Value");
       return (
         <div>
           <h1>
             <state$.Value />
           </h1>
-          <button onClick={() => state$.setValue("First Value")}>
-            First button
-          </button>
-          <button onClick={() => state$.setValue("Second Value")}>
+          <button onClick={() => setState("First Value")}>First button</button>
+          <button onClick={() => setState("Second Value")}>
             Second button
           </button>
         </div>
@@ -39,7 +37,7 @@ describe("useLucyState", () => {
     const spy = jest.fn();
     const user = userEvent.setup();
     function Component() {
-      const state$ = useLucyState("Initial Value");
+      const [state$, setState] = useLucyState("Initial Value");
       useEffect(() => {
         spy();
       });
@@ -48,10 +46,8 @@ describe("useLucyState", () => {
           <h1>
             <state$.Value />
           </h1>
-          <button onClick={() => state$.setValue("First Value")}>
-            First button
-          </button>
-          <button onClick={() => state$.setValue("Second Value")}>
+          <button onClick={() => setState("First Value")}>First button</button>
+          <button onClick={() => setState("Second Value")}>
             Second button
           </button>
         </div>


### PR DESCRIPTION
## Description

I found that without splitting it makes the intent to change values not so pronounced, which is probably not a great thing. It also makes TypeScript tricky to deal with, as if allow `LucyState<T | undefined>`, passing `<LucyState<T>` will complain because `setValue` will not be compatible.

I guess there is a reason why React splits it and returns them in a tuple :)

## Reference

Closes https://github.com/Bloomca/react-lucy-state/issues/17